### PR TITLE
여러명에게 보낼 수 있도록 extension에 배율 넣는 방법을 추가

### DIFF
--- a/app/Nurigo/Api/GroupMessage.php
+++ b/app/Nurigo/Api/GroupMessage.php
@@ -94,37 +94,90 @@ class GroupMessage extends Coolsms
      */
     public function addMessages($options) 
     {
+
         if (!isset($options->group_id) || !isset($options->to) || !isset($options->text) || !isset($options->from)) {
             throw new CoolsmsSDKException('group_id, to, text, from is required', 202);
         }
         $args = new \stdClass();
         $args->messages = array();
-        $args->messages[0] = new \stdClass();
-        $sendNumber = explode(',', $options->to);
-        $args->messages[0]->to = new \stdClass();
-        $args->messages[0]->to->recipients = $sendNumber;
-        $args->messages[0]->from = $options->from;
-        $args->messages[0]->text = $options->text;
-        if ($options->type) {
-            $args->messages[0]->type = $options->type;
+        if (!empty($options->extension)) {
+            foreach ($options->extension as $key => $value) {
+                if (!$value->to || !$value->text) {
+                    continue;
+                }
+
+                $args->messages[$key] = new \stdClass();
+                $sendNumber = explode(',', $value->to);
+                $args->messages[$key]->to = new \stdClass();
+                $args->messages[$key]->to->recipients = $sendNumber;
+                $args->messages[$key]->from = $options->from;
+                $args->messages[$key]->text = $value->text;
+                if ($options->type) {
+                    $args->messages[$key]->type = $options->type;
+                } else {
+                    $args->messages[$key]->type = 'SMS';
+                }
+
+                if ($options->country) {
+                    $args->messages[$key]->country = $options->country;
+                }
+
+                if ($options->subject) {
+                    $args->messages[$key]->subject = $options->subject;
+                }
+
+                if ($options->imageId) {
+                    $args->messages[$key]->imageId = $options->imageId;
+                }
+
+                if ($options->kakaoOptions) {
+                    $args->messages[$key]->kakaoOptions = new \stdClass();
+                    if ($options->kakaoOptions->senderKey) {
+                        $args->messages[$key]->kakaoOptions->senderKey = $options->kakaoOptions->senderKey;
+                    }
+
+                    if ($options->kakaoOptions->templateCode) {
+                        $args->messages[$key]->kakaoOptions->templateCode = $options->kakaoOptions->templateCode;
+                    }
+
+                    if ($options->kakaoOptions->buttonName) {
+                        $args->messages[$key]->kakaoOptions->buttonName = $options->kakaoOptions->buttonName;
+                    }
+
+                    if ($options->kakaoOptions->buttonUrl) {
+                        $args->messages[$key]->kakaoOptions->buttonUrl = $options->kakaoOptions->buttonUrl;
+                    }
+                }
+
+            }
         } else {
-            $args->messages[0]->type = 'SMS';
-        }
-        if ($options->country) {
-            $args->messages[0]->country = $options->country;
-        }
-        if ($options->subject) {
-            $args->messages[0]->subject = $options->subject;
-        }
-        if ($options->imageId) {
-            $args->messages[0]->imageId = $options->imageId;
-        }
-        if ($options->kakaoOptions) {
-            $args->messages[0]->kakaoOptions = new \stdClass();
-            if($options->kakaoOptions->senderKey) $args->messages[0]->kakaoOptions->senderKey = $options->kakaoOptions->senderKey;
-            if($options->kakaoOptions->templateCode) $args->messages[0]->kakaoOptions->templateCode = $options->kakaoOptions->templateCode;
-            if($options->kakaoOptions->buttonName) $args->messages[0]->kakaoOptions->buttonName = $options->kakaoOptions->buttonName;
-            if($options->kakaoOptions->buttonUrl) $args->messages[0]->kakaoOptions->buttonUrl = $options->kakaoOptions->buttonUrl;
+            $args->messages[0] = new \stdClass();
+            $sendNumber = explode(',', $options->to);
+            $args->messages[0]->to = new \stdClass();
+            $args->messages[0]->to->recipients = $sendNumber;
+            $args->messages[0]->from = $options->from;
+            $args->messages[0]->text = $options->text;
+            if ($options->type) {
+                $args->messages[0]->type = $options->type;
+            } else {
+                $args->messages[0]->type = 'SMS';
+            }
+            if ($options->country) {
+                $args->messages[0]->country = $options->country;
+            }
+            if ($options->subject) {
+                $args->messages[0]->subject = $options->subject;
+            }
+            if ($options->imageId) {
+                $args->messages[0]->imageId = $options->imageId;
+            }
+            if ($options->kakaoOptions) {
+                $args->messages[0]->kakaoOptions = new \stdClass();
+                if($options->kakaoOptions->senderKey) $args->messages[0]->kakaoOptions->senderKey = $options->kakaoOptions->senderKey;
+                if($options->kakaoOptions->templateCode) $args->messages[0]->kakaoOptions->templateCode = $options->kakaoOptions->templateCode;
+                if($options->kakaoOptions->buttonName) $args->messages[0]->kakaoOptions->buttonName = $options->kakaoOptions->buttonName;
+                if($options->kakaoOptions->buttonUrl) $args->messages[0]->kakaoOptions->buttonUrl = $options->kakaoOptions->buttonUrl;
+            }
         }
 
         $encoding_json_data = json_encode($args);

--- a/examples/GroupMessage/example_add_messages.php
+++ b/examples/GroupMessage/example_add_messages.php
@@ -28,7 +28,7 @@ try {
     $options->group_id = 'GID56CC00E21C4DC';	// group id
 
     // Optional parameters for your own needs
-    // $options->type = 'SMS';                       // Message type ( SMS, LMS, MMS, ATA )
+    // $options->type = 'SMS';                       // Message type ( SMS, LMS, MMS, ATA, CTA )
     // $options->image_id = 'IM289E9CISNWIC'	       // image_id. type must be set as 'MMS'
     // $options->country = 82;		                   // Korea(82) Japan(81) America(1) China(86) Default is Korea
     // $options->subject = 'Hello World';		         // set msg title for LMS and MMS
@@ -37,6 +37,28 @@ try {
     // $options->kakaoOptions->templateCode = 'C001'; // 알림톡 발송시 해당 템플릿검사를 위한 템플릿 코드
     // $options->kakaoOptions->buttonName = '바로가기'; // 알림톡과 친구톡에서 바로가기 링크버튼의 이름
     // $options->kakaoOptions->buttonUrl = 'https://www.coolsms.co.kr/'; // 알림톡 바로가기 링크 버튼클릭시 이동할 링크주소
+
+    /**
+     * 문자전송을 여러명에게 하는 기능.
+     * 여러명에게 문자를 전송하기위해 오브젝트 생성하여 문자 전송을 해야함.
+     * 필요한 갯수만큼의 오브젝트를 만들어서 $options->extension array을 넘겨주면 됩니다.
+     * 자동으로 PHP에서 처리가능할 경우 foreach 문을 통해서 정보를 가져와 각자의 데이터에 따로 사용할 수 있도록 하는것이 편합니다.
+     */
+    /* e.g) 소스코드
+    $args = new stdClass();
+    $args->to = '01000000000'; // 수신번호
+    $args->text = '안녕하세요. 여러명 문자 전송기능입니다.'; // 문자내용
+    $sendArrays = array(
+        $args, // $args2, $args3 도 동일하게 오브젝트 만들어 생성.
+    );
+    $options->extension = array();
+    foreach ($sendArrays as $value) {
+        $sendObject = new stdClass();
+        $sendObject->to = $value->to;
+        $sendObject->text = $value->text;
+        $options->extension[] = $sendObject;
+    }
+    */
 
     $result = $rest->addMessages($options);
     print_r($result);

--- a/examples/GroupMessage/example_send_process.php
+++ b/examples/GroupMessage/example_send_process.php
@@ -17,28 +17,61 @@ $api_key = '#ENTER_YOUR_OWN#';
 $api_secret = '#ENTER_YOUR_OWN#';
 
 try {
-	$options = new stdClass();
+    $options = new stdClass();
 
     // initiate rest api sdk object
-	$rest = new GroupMessage($api_key, $api_secret);
+    $rest = new GroupMessage($api_key, $api_secret);
 
     // create group
-	$result = $rest->createGroup($options);
-	$group_id = $result->group_id;
-	print_r($result);
+    $result = $rest->createGroup($options);
+    $group_id = $result->group_id;
+    print_r($result);
 
-	// add messages
-	$options->to = '01000000000';
+    // add messages
+    $options->to = '01000000000';
     $options->from = '01000000000';
     $options->text = '안녕하세요. 10000건을 20초안에 발송하는 빠르고 저렴한 CoolSMS의 테스팅 문자입니다. ';
-	$options->group_id = $group_id;	// group id
-	$result = $rest->addMessages($options);
-	print_r($result);
+    $options->group_id = $group_id;    // group id
 
-	// send messages
-	$result = $rest->sendGroupMessage($group_id);
+    // Optional parameters for your own needs
+    // $options->type = 'SMS';                       // Message type ( SMS, LMS, MMS, ATA, CTA )
+    // $options->image_id = 'IM289E9CISNWIC'	       // image_id. type must be set as 'MMS'
+    // $options->country = 82;		                   // Korea(82) Japan(81) America(1) China(86) Default is Korea
+    // $options->subject = 'Hello World';		         // set msg title for LMS and MMS
+    // $options->kakaoOptions = new stdClass(); // 알림톡 혹은 친구톡을 전송할때 한번 초기화 필요.
+    // $options->kakaoOptions->senderKey = '55540253a3e61072...'; // 발급받은 snederKey
+    // $options->kakaoOptions->templateCode = 'C001'; // 알림톡 발송시 해당 템플릿검사를 위한 템플릿 코드
+    // $options->kakaoOptions->buttonName = '바로가기'; // 알림톡과 친구톡에서 바로가기 링크버튼의 이름
+    // $options->kakaoOptions->buttonUrl = 'https://www.coolsms.co.kr/'; // 알림톡 바로가기 링크 버튼클릭시 이동할 링크주소
+
+    /**
+     * 문자전송을 여러명에게 하는 기능.
+     * 여러명에게 문자를 전송하기위해 오브젝트 생성하여 문자 전송을 해야함.
+     * 필요한 갯수만큼의 오브젝트를 만들어서 $options->extension array을 넘겨주면 됩니다.
+     * 자동으로 PHP에서 처리가능할 경우 foreach 문을 통해서 정보를 가져와 각자의 데이터에 따로 사용할 수 있도록 하는것이 편합니다.
+     */
+    /* e.g) 소스코드
+    $args = new stdClass();
+    $args->to = '01000000000'; // 수신번호
+    $args->text = '안녕하세요. 여러명 문자 전송기능입니다.'; // 문자내용
+    $sendArrays = array(
+        $args, // $args2, $args3 도 동일하게 오브젝트 만들어 생성.
+    );
+    $options->extension = array();
+    foreach ($sendArrays as $value) {
+        $sendObject = new stdClass();
+        $sendObject->to = $value->to;
+        $sendObject->text = $value->text;
+        $options->extension[] = $sendObject;
+    }
+    */
+    $result = $rest->addMessages($options);
     print_r($result);
-} catch(CoolsmsException $e) {
+
+    // send messages
+    $result = $rest->sendGroupMessage($group_id);
+    print_r($result);
+} catch (CoolsmsException $e) {
     echo $e->getMessage(); // get error message
     echo $e->getCode(); // get error code
 }


### PR DESCRIPTION
현제 한명에게만 문자전송이 가능한 상태로 되어있습니다.

이를 여러명에게 보낼 수 있도록 extension 방식(퍼플북방식)을 주도록 하여 여러명에게 전송을 요청 할 수 있도록 API를 구조화하였습니다. 
마찬가지로 $options->to 에 여러명을 `,` 으로 구분하도록 하여 자동으로 여러전화번호에 대한 지원이 원활하도록 되어있습니다 